### PR TITLE
Update to latest flow commit, make voice-id configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,8 @@
 /target
 /resources/secrets.edn
 /core/resources/secrets.edn
-/core/.clj-kondo/.cache
 /core/.lsp/
 /examples/.calva/
-/.idea/
-/core/.idea/
-/core/core.iml
+.idea/
+.clj-kondo/
+*.iml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ This project's status is **_experimental_**. Expect breaking changes.
 
 
 ## Quick Start: Local example
+
+First, create a `resources/secrets.edn`:
+
+```edn
+{:deepgram {:api-key ""}
+ :elevenlabs {:api-key ""
+              :voice-id ""}
+ :groq {:api-key ""}
+ :openai {:new-api-sk ""}}
+```
+
+Obtain the API keys from the respective providers and fill in the blank values.
+
+Start a REPL and evaluate the snippets in the `(comment ...)` blocks to start the flows.
+Allow Microphone access when prompted.
+
 ```clojure
 (ns voice-fn-examples.local
   (:require

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         org.uncomplicate/clojure-sound {:mvn/version "0.3.0"}
         com.taoensso/telemere {:mvn/version "1.0.0-RC1"}
         metosin/malli {:mvn/version "0.17.0"}
-        org.clojure/core.async {:git/sha "0529d79f1b73a4788567f9b571f8b423657bb409" :git/url "https://github.com/clojure/core.async"}
+        org.clojure/core.async {:git/sha "88a7971196cd41fbc921df3f4c36a004a3f974d6" :git/url "https://github.com/clojure/core.async"}
         metosin/jsonista {:mvn/version "0.3.8"}
         com.microsoft.onnxruntime/onnxruntime {:mvn/version "1.20.0"}
         com.microsoft.onnxruntime/onnxruntime_gpu {:mvn/version "1.20.0"}

--- a/examples/src/voice_fn_examples/local.clj
+++ b/examples/src/voice_fn_examples/local.clj
@@ -97,7 +97,7 @@
          :tts {:proc tts/elevenlabs-tts-process
                :args {:elevenlabs/api-key (secret [:elevenlabs :api-key])
                       :elevenlabs/model-id "eleven_flash_v2_5"
-                      :elevenlabs/voice-id "7sJPxFeMXAVWZloGIqg2"
+                      :elevenlabs/voice-id (secret [:elevenlabs :voice-id])
                       :voice/stability 0.5
                       :voice/similarity-boost 0.8
                       :voice/use-speaker-boost? true

--- a/examples/src/voice_fn_examples/scenario_example.clj
+++ b/examples/src/voice_fn_examples/scenario_example.clj
@@ -71,7 +71,7 @@
                               :tools []}
 
                 ;; add gateway process for scenario to inject frames
-                :extra-procs {:scenario {:proc (flow/step-process #'sm/scenario-in-process)}}
+                :extra-procs {:scenario {:proc (flow/process #'sm/scenario-in-process)}}
                 :extra-conns [[[:scenario :speak-out] [:tts :in]]
                               [[:scenario :context-out] [:context-aggregator :in]]]})
 
@@ -102,5 +102,4 @@
 
   ;; Stop the conversation
   (flow/stop (:flow s))
-
   ,)

--- a/examples/src/voice_fn_examples/twilio_websocket.clj
+++ b/examples/src/voice_fn_examples/twilio_websocket.clj
@@ -121,7 +121,7 @@
         :tts {:proc tts/elevenlabs-tts-process
               :args {:elevenlabs/api-key (secret [:elevenlabs :api-key])
                      :elevenlabs/model-id "eleven_flash_v2_5"
-                     :elevenlabs/voice-id "7sJPxFeMXAVWZloGIqg2"
+                     :elevenlabs/voice-id (secret [:elevenlabs :voice-id])
                      :voice/stability 0.5
                      :voice/similarity-boost 0.8
                      :voice/use-speaker-boost? true

--- a/src/voice_fn/processors/elevenlabs.clj
+++ b/src/voice_fn/processors/elevenlabs.clj
@@ -30,9 +30,9 @@
   (let [{:audio.out/keys [encoding sample-rate]
          :flow/keys [language]
          :elevenlabs/keys [model-id voice-id]
-         :or {model-id "eleven_flash_v2_5"
-              voice-id "cjVigY5qzO86Huf0OWal"}}
+         :or {model-id "eleven_flash_v2_5"}}
         args]
+    (assert voice-id "Voice ID is required")
     (u/append-search-params (format xi-tts-websocket-url voice-id)
                             {:model_id model-id
                              :language_code language
@@ -42,7 +42,7 @@
   (make-elevenlabs-ws-url
     {:elevenlabs/api-key (secrets/secret [:elevenlabs :api-key])
      :elevenlabs/model-id "eleven_flash_v2_5"
-     :elevenlabs/voice-id "7sJPxFeMXAVWZloGIqg2"
+     :elevenlabs/voice-id (secrets/secret [:elevenlabs :voice-id])
      :voice/stability 0.5
      :voice/similarity-boost 0.8
      :voice/use-speaker-boost? true}))

--- a/src/voice_fn/processors/llm_context_aggregator.clj
+++ b/src/voice_fn/processors/llm_context_aggregator.clj
@@ -334,6 +334,7 @@ S: Start, E: End, T: Transcription, I: Interim, X: Text
   ([] {:ins {:in "Channel for llm text chunks"}
        :outs {:out "Channel for assembled speak frames"}})
   ([_] {:acc nil})
+  ([state _] state)
   ([{:keys [acc]} _ msg]
    (when (frame/llm-text-chunk? msg)
      (let [{:keys [sentence accumulator]} (u/assemble-sentence acc (:frame/data msg))]
@@ -375,4 +376,4 @@ S: Start, E: End, T: Transcription, I: Interim, X: Text
 (def llm-sentence-assembler
   "Takes in llm-text-chunk frames and returns a full sentence. Useful for
   generating speech sentence by sentence, instead of waiting for the full LLM message."
-  (flow/step-process #'llm-sentence-assembler-impl))
+  (flow/process #'llm-sentence-assembler-impl))

--- a/src/voice_fn/scenario_manager.clj
+++ b/src/voice_fn/scenario_manager.clj
@@ -135,6 +135,7 @@
        :outs {:speak-out "Channel where speak-frames will be put. Should be connected to text to speech process"
               :context-out "Channel where context frames will be put"}})
   ([_] nil)
+  ([state _] state)
   ([_ _ frame]
    [nil (cond-> {:context-out [frame]}
           (frame/speak-frame? frame) (assoc :speak-out [frame]))]))


### PR DESCRIPTION
These changes were needed to make the local and scenario examples work on my machine.

The hard-coded Eleven Labs voice ID was failing with 'Voice ID not found' error.
This change makes it configurable in secrets.edn. The voice-id can be obtained from [their playground](https://help.elevenlabs.io/hc/en-us/articles/14599760033937-How-do-I-find-my-voices-ID-of-my-voices-via-the-website-and-through-the-API). 

I've also updated core.async.flow to the latest commit (88a7971196cd41fbc921df3f4c36a004a3f974d6).
Two changes were necessary - adding the arity-2 `:transform` functions which just return the state and `step-process` is no longer needed (https://github.com/clojure/core.async/commit/8bd11b70024a7b092ba324261c905b1ed1b6dcb2).