### PR TITLE
Small fixes

### DIFF
--- a/src/voice_fn/processors/llm_context_aggregator.clj
+++ b/src/voice_fn/processors/llm_context_aggregator.clj
@@ -243,7 +243,7 @@ S: Start, E: End, T: Transcription, I: Interim, X: Text
             ;; function, to wait for the new context
             ;; messages from the new scenario node
             :properties {:run-llm? (nil? transition-cb)
-                         :on-update #(transition-cb args)}}))
+                         :on-update #(when transition-cb (transition-cb args))}}))
        (frame/llm-tool-call-result
          {:request tool-call-msg
           :result (tool-result-adapter {:result "Tool not found"

--- a/src/voice_fn/utils/core.clj
+++ b/src/voice_fn/utils/core.clj
@@ -175,4 +175,4 @@
   "Monotonic time in milliseconds. Used to check if we should send the next chunk
   of audio."
   []
-  (int (/ (System/nanoTime)  1e6)))
+  (long (/ (System/nanoTime)  1e6)))


### PR DESCRIPTION
A couple of small fixes included : 

- On the current main, when running the local example I get a NPE because transition-cb is null.

- Also  `(/ (System/nanoTime)  1e6)` doesn't fit on a Integer.

```clojure
Clojure 1.12.0
user=> (int (/ (System/nanoTime)  1e6))
Execution error (IllegalArgumentException) at user/eval3 (REPL:1).
Value out of range for int: 2.82624472293198E9
```