### PR TITLE
add missing protocols import

### DIFF
--- a/src/simulflow/schema.clj
+++ b/src/simulflow/schema.clj
@@ -4,7 +4,8 @@
    [malli.core :as m]
    [malli.error :as me]
    [malli.transform :as mt]
-   [malli.util :as mu]))
+   [malli.util :as mu]
+   [clojure.core.async.impl.protocols :as async-protocols]))
 
 (defn parse-schema
   [s]


### PR DESCRIPTION
Build was failing, noticed it was missing an import in src/simulflow/schema.clj.